### PR TITLE
Update asciidoc-reference-check.js

### DIFF
--- a/lib/asciidoc-reference-check.js
+++ b/lib/asciidoc-reference-check.js
@@ -137,6 +137,30 @@ module.exports = {
                                 //anchorArray.push(line);
                             }
 
+                            //find if line contains an anchor with format "- [[[anchor]]]" or "- [[[anchor, something]]]"
+                            //this type of format of used for bibliography
+                            if (line.match(/^[ \t]*[\*\-]+[ \t]+\[\[\[[^\]]+\]\]\]/g) && !line.startsWith('//')) {
+                                var extractLink = line.match(/\[\[\[[^\]]+\]\]\]/g);
+                                //console.log("LINE: "+ line);
+                                //console.log("EXTRACT LINK: "+ extractLink);
+                                for (var i = 0; i < extractLink.length; i++) {
+                                    var newAnchor = extractLink[i];
+                                    newAnchor = newAnchor.replace("[[[", "");
+                                    newAnchor = newAnchor.replace("]]]", "");
+
+                                    //take care of anchors with comma
+                                    if (newAnchor.match(/,/g)) {
+                                        var tempTxt = newAnchor.split(",")
+                                        newAnchor = tempTxt[0];
+                                    }
+
+                                    anchorArray.push(newAnchor);
+                                    //console.log("NEW ANCHOR with [[[...]]]: " + newAnchor);
+
+                                }
+                                //anchorArray.push(line);
+                            }
+                            
                             //find if line contains anchor with format [#anchorname] (Inline anchors)
                             if (line.match(/(\[#)[^]*?\]/g)) {
                                 var extractLink = line.match(/(\[#)[^]*?\]/g)


### PR DESCRIPTION
With this pull request, I added support for bibkiography anchors (with tripple square brackets) as defined here:
https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#bibliography

